### PR TITLE
Fix: PHPStan ignores

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -28,6 +28,8 @@ use Utopia\Registry\Registry;
 use Utopia\Swoole\Request;
 use Utopia\Swoole\Response;
 
+use function Swoole\Coroutine\run;
+
 Runtime::enableCoroutine(true, SWOOLE_HOOK_ALL);
 
 App::setMode((string) App::getEnv('OPEN_RUNTIMES_PROXY_ENV', App::MODE_TYPE_PRODUCTION));
@@ -273,66 +275,63 @@ App::error()
         $response->json($output);
     });
 
-/** @phpstan-ignore-next-line */
-Co\run(
-    function () use ($register) {
-        // If no health check, mark all as online
-        if (App::getEnv('OPEN_RUNTIMES_PROXY_HEALTHCHECK', 'enabled') === 'disabled') {
-            /**
-             * @var Table $state
-             */
-            $state = $register->get('state');
-            $executors = \explode(',', (string) App::getEnv('OPEN_RUNTIMES_PROXY_EXECUTORS', ''));
+run(function () use ($register) {
+    // If no health check, mark all as online
+    if (App::getEnv('OPEN_RUNTIMES_PROXY_HEALTHCHECK', 'enabled') === 'disabled') {
+        /**
+         * @var Table $state
+         */
+        $state = $register->get('state');
+        $executors = \explode(',', (string) App::getEnv('OPEN_RUNTIMES_PROXY_EXECUTORS', ''));
 
-            foreach ($executors as $executor) {
-                $state->set($executor, [
-                    'status' => 'online',
-                    'hostname' => $executor,
-                    'state' =>  \json_encode([])
-                ]);
-            }
-
-            return;
+        foreach ($executors as $executor) {
+            $state->set($executor, [
+                'status' => 'online',
+                'hostname' => $executor,
+                'state' =>  \json_encode([])
+            ]);
         }
 
-        // Initial health check + start timer
-        healthCheck($register, true);
-
-        $defaultInterval = '10000'; // 10 seconds
-        Timer::tick(\intval(App::getEnv('OPEN_RUNTIMES_PROXY_HEALTHCHECK_INTERVAL', $defaultInterval)), fn () => healthCheck($register, false));
-
-        $server = new Server('0.0.0.0', 80, false);
-
-        $server->handle('/', function (SwooleRequest $swooleRequest, SwooleResponse $swooleResponse) {
-            $request = new Request($swooleRequest);
-            $response = new Response($swooleResponse);
-
-            $app = new App('UTC');
-
-            try {
-                $app->run($request, $response);
-            } catch (\Throwable $th) {
-                $code = 500;
-
-                /**
-                 * @var Logger $logger
-                 */
-                $logger = $app->getResource('logger');
-                logError($th, "serverError", $logger);
-                $swooleResponse->setStatusCode($code);
-                $output = [
-                    'message' => 'Error: ' . $th->getMessage(),
-                    'code' => $code,
-                    'file' => $th->getFile(),
-                    'line' => $th->getLine(),
-                    'trace' => $th->getTrace()
-                ];
-                $swooleResponse->end(\json_encode($output));
-            }
-        });
-
-        Console::success('Functions proxy is ready.');
-
-        $server->start();
+        return;
     }
-);
+
+    // Initial health check + start timer
+    healthCheck($register, true);
+
+    $defaultInterval = '10000'; // 10 seconds
+    Timer::tick(\intval(App::getEnv('OPEN_RUNTIMES_PROXY_HEALTHCHECK_INTERVAL', $defaultInterval)), fn () => healthCheck($register, false));
+
+    $server = new Server('0.0.0.0', 80, false);
+
+    $server->handle('/', function (SwooleRequest $swooleRequest, SwooleResponse $swooleResponse) {
+        $request = new Request($swooleRequest);
+        $response = new Response($swooleResponse);
+
+        $app = new App('UTC');
+
+        try {
+            $app->run($request, $response);
+        } catch (\Throwable $th) {
+            $code = 500;
+
+            /**
+             * @var Logger $logger
+             */
+            $logger = $app->getResource('logger');
+            logError($th, "serverError", $logger);
+            $swooleResponse->setStatusCode($code);
+            $output = [
+                'message' => 'Error: ' . $th->getMessage(),
+                'code' => $code,
+                'file' => $th->getFile(),
+                'line' => $th->getLine(),
+                'trace' => $th->getTrace()
+            ];
+            $swooleResponse->end(\json_encode($output));
+        }
+    });
+
+    Console::success('Functions proxy is ready.');
+
+    $server->start();
+});

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "scripts": {
         "lint": "./vendor/bin/pint --preset psr12 --test",
         "format": "./vendor/bin/pint --preset psr12",
-        "check": "./vendor/bin/phpstan analyse --level max app src tests",
+        "check": "./vendor/bin/phpstan analyse --level max -c phpstan.neon app src tests",
         "test": "./vendor/bin/phpunit --configuration phpunit.xml --debug"
     },
     "require": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+    scanDirectories:
+      - vendor/swoole/ide-helper

--- a/src/Proxy/Health/Health.php
+++ b/src/Proxy/Health/Health.php
@@ -4,6 +4,8 @@ namespace OpenRuntimes\Proxy\Health;
 
 use Utopia\App;
 
+use function Swoole\Coroutine\batch;
+
 class Health
 {
     /**
@@ -75,10 +77,7 @@ class Health
             };
         }
 
-        /** @phpstan-ignore-next-line */
-        \Swoole\Coroutine\batch(
-            $callables
-        );
+        batch($callables);
 
         return $this;
     }

--- a/tests/HealthTest.php
+++ b/tests/HealthTest.php
@@ -6,33 +6,32 @@ use OpenRuntimes\Proxy\Health\Health;
 use OpenRuntimes\Proxy\Health\Node;
 use PHPUnit\Framework\TestCase;
 
+use function Swoole\Coroutine\run;
+
 class HealthTest extends TestCase
 {
     public function testHealth(): void
     {
-        /** @phpstan-ignore-next-line */
-        \Co\run(
-            function () {
-                $health = new Health();
+        run(function () {
+            $health = new Health();
 
-                $nodes = $health
-                    ->addNode(new Node('server1'))
-                    ->addNode(new Node('mockoon1'))
-                    ->run()
-                    ->getNodes();
+            $nodes = $health
+                ->addNode(new Node('server1'))
+                ->addNode(new Node('mockoon1'))
+                ->run()
+                ->getNodes();
 
-                $this->assertIsArray($nodes);
-                $this->assertCount(2, $nodes);
+            $this->assertIsArray($nodes);
+            $this->assertCount(2, $nodes);
 
-                $serverNode = $nodes[0];
-                $mockoonNode = $nodes[1];
+            $serverNode = $nodes[0];
+            $mockoonNode = $nodes[1];
 
-                $this->assertFalse($serverNode->isOnline());
-                $this->assertArrayHasKey('message', $serverNode->getState());
+            $this->assertFalse($serverNode->isOnline());
+            $this->assertArrayHasKey('message', $serverNode->getState());
 
-                $this->assertTrue($mockoonNode->isOnline());
-                $this->assertArrayHasKey('status', $mockoonNode->getState());
-            }
-        );
+            $this->assertTrue($mockoonNode->isOnline());
+            $this->assertArrayHasKey('status', $mockoonNode->getState());
+        });
     }
 }


### PR DESCRIPTION
Removed multiple PHPStan ignores. Instead of ignoring missing Swoole function, PHPStan now looks at ide-helper for source of definitions.