### PR TITLE
Fix: 0 exit code

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -376,8 +376,6 @@ run(function () use ($register) {
                 'state' =>  \json_encode([])
             ]);
         }
-
-        return;
     }
 
     // Initial health check + start timer


### PR DESCRIPTION
Bug when health check=disabled cause proxy to never start, instead, exit with 0 exit code.