### PR TITLE
Fix: usage balancing

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -279,6 +279,7 @@ App::wildcard()
             }
 
             $stateItem['runtimes'][$runtimeId]['status'] = 'pass';
+            $stateItem['runtimes'][$runtimeId]['usage'] = 0;
 
             $record['state'] = \json_encode($stateItem);
 


### PR DESCRIPTION
New containers were considered 100% cpu usage, and ignored as ideal option.

Now it's considered 0%cpu usage, as the most ideal option.

This prevents proxy from ignoring CPU usage in a high local environment.