### PR TITLE
Feat: Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,6 @@ RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini
 
 EXPOSE 80
 
+HEALTHCHECK --interval=30s --timeout=15s --start-period=60s --retries=3 CMD curl -s -H "Authorization: Bearer ${OPR_PROXY_SECRET}" --fail http://127.0.0.1:80/v1/proxy/health
+
 CMD [ "php", "app/http.php" ]

--- a/app/http.php
+++ b/app/http.php
@@ -271,6 +271,14 @@ Http::init()
         }
     });
 
+Http::get('/v1/proxy/health')
+    ->inject('response')
+    ->action(function (Response $response) {
+        $response
+            ->setStatusCode(200)
+            ->send('OK');
+    });
+
 Http::wildcard()
     ->inject('balancer')
     ->inject('request')

--- a/tests/HTTPTest.php
+++ b/tests/HTTPTest.php
@@ -13,9 +13,17 @@ class HTTPTest extends TestCase
         $this->client = new Client();
 
         $this->client
-            ->setEndpoint('http://openruntimes-proxy/')
+            ->setEndpoint('http://openruntimes-proxy')
             ->addHeader('authorization', 'Bearer proxy-secret-key');
         ;
+    }
+
+    public function testHealthEndpoint(): void
+    {
+        $response = (array) $this->client->call(Client::METHOD_GET, '/v1/proxy/health');
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('OK', $response['body']);
     }
 
     public function testBalancer(): void


### PR DESCRIPTION
QA:

100% healthy:

![CleanShot 2024-02-29 at 13 53 36@2x](https://github.com/open-runtimes/proxy/assets/19310830/61604159-2fb4-448c-bda6-ada648d5488f)


100% unhealthy:

![CleanShot 2024-02-29 at 13 48 32@2x](https://github.com/open-runtimes/proxy/assets/19310830/b89174e6-e0d9-4dd0-b117-31086e3f53f8)


70% healthy:

![CleanShot 2024-02-29 at 13 45 10@2x](https://github.com/open-runtimes/proxy/assets/19310830/f0a90b8e-acaa-47e0-bd47-df5c492962f0)
