### PR TITLE
Prevent a health check error from crashing the proxy

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -220,7 +220,11 @@ $healthCheck = function (bool $forceShowError = false) use ($register): void {
     }
 
     if (Http::getEnv('OPR_PROXY_HEALTHCHECK_URL', '') !== '' && $healthy) {
-        Client::fetch(Http::getEnv('OPR_PROXY_HEALTHCHECK_URL', '') ?? '');
+        try {
+            Client::fetch(Http::getEnv('OPR_PROXY_HEALTHCHECK_URL', '') ?? '');
+        } catch (\Throwable $th) {
+            logError($th, 'healthCheckError', $logger, null);
+        }
     }
 };
 


### PR DESCRIPTION
Before:

<img width="729" alt="image" src="https://github.com/open-runtimes/proxy/assets/1477010/8a197872-53b4-4d61-8153-dcb420a227e6">

After:

<img width="783" alt="image" src="https://github.com/open-runtimes/proxy/assets/1477010/ea7c5e91-92ff-47cf-a87c-11867a68bf50">
