### PR TITLE
Fix: Chunked response proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,20 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist
 
 # Prepare generic compiler
-FROM php:8.0.18-cli-alpine3.15 as compile
+FROM php:8.3.7-cli-alpine3.19 as compile
 
-ENV PHP_SWOOLE_VERSION=v4.8.10
+ENV PHP_SWOOLE_VERSION=v5.1.2
 
 RUN \
   apk add --no-cache --virtual .deps \
   make \
   automake \
   autoconf \
+  curl-dev \
   gcc \
   g++ \
   git \
+  linux-headers \
   openssl-dev
   
 RUN docker-php-ext-install sockets
@@ -33,12 +35,12 @@ RUN \
   git clone --depth 1 --branch $PHP_SWOOLE_VERSION https://github.com/swoole/swoole-src.git && \
   cd swoole-src && \
   phpize && \
-  ./configure --enable-sockets --enable-http2 --enable-openssl && \
+  ./configure --enable-sockets --enable-http2 --enable-openssl --enable-swoole-curl && \
   make && make install && \
   cd ..
 
 # Proxy
-FROM php:8.0.18-cli-alpine3.15 as final
+FROM php:8.3.7-cli-alpine3.19 as final
 
 ARG OPR_PROXY_VERSION
 ENV OPR_PROXY_VERSION=$OPR_PROXY_VERSION
@@ -68,7 +70,7 @@ COPY ./src /usr/local/src
 
 # Extensions and libraries
 COPY --from=composer /usr/local/src/vendor /usr/local/vendor
-COPY --from=swoole /usr/local/lib/php/extensions/no-debug-non-zts-20200930/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
+COPY --from=swoole /usr/local/lib/php/extensions/no-debug-non-zts-20230831/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20230831/
 
 RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini
 


### PR DESCRIPTION
Proxying chunked response didnt work, causing build logs in Appwrite to not be realtime.

This fixed the problem. It's copy&paste solution that was implemented in OPR executor for chunked support: https://github.com/open-runtimes/executor/pull/76/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557