### PR TITLE
Chores: Deprecate ARM v6 v7 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           build-args: |
             OPR_PROXY_VERSION=${{ env.TAG }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ env.IMAGE_NAME }}:latest,${{ env.IMAGE_NAME }}:${{ env.TAG }}


### PR DESCRIPTION
This PR is trying to fix release failure.

Action for release failed: https://github.com/open-runtimes/proxy/actions/runs/10349967357

This is the only difference that could possibly fail it, compared to executor: https://github.com/open-runtimes/executor/blob/main/.github/workflows/release.yml#L38